### PR TITLE
ci: update review workflow actions

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -22,6 +22,8 @@ jobs:
         with:
           node-version: "22.15.1"
           cache: pnpm
+      - name: Setup reviewdog
+        uses: reviewdog/action-setup@v1.3.2
       - run: pnpm install
       - uses: EPMatt/reviewdog-action-tsc@v1
         with:
@@ -45,6 +47,8 @@ jobs:
         with:
           node-version: "22.15.1"
           cache: pnpm
+      - name: Setup reviewdog
+        uses: reviewdog/action-setup@v1.3.2
       - run: pnpm install
       - name: Run Biome with reviewdog
         uses: mongolyy/reviewdog-action-biome@v1.12.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -14,6 +14,7 @@ onlyBuiltDependencies:
   - "@biomejs/biome"
   - "@moonrepo/cli"
   - "@swc/core"
+  - "@tailwindcss/oxide"
   - esbuild
   - msw
   - sharp


### PR DESCRIPTION
- Update the review workflow to use node version 22.15.1
- Update the review workflow to use reviewdog action setup v1.3.2
- Update the review workflow to use biome reviewdog action v1.12.0

Signed-off-by: DanSnow <dododavid006@gmail.com>
