### PR TITLE
fix(content): ensure card visibility in Google search results

### DIFF
--- a/content/ContentUI.tsx
+++ b/content/ContentUI.tsx
@@ -29,7 +29,7 @@ export function ContentUI() {
 
   return (
     <div className={cn({ dark: isDark })}>
-      <HoarderCard key={userQuery} userQuery={userQuery} />
+      <HoarderCard key={userQuery} userQuery={userQuery} className="min-w-[25rem]" />
       <Toaster />
       <div ref={setContainer} />
     </div>


### PR DESCRIPTION
This PR addresses a display issue with the HoarderCard component on Google search result pages. Previously, the card's width could become too narrow due to container constraints, causing its content (like bookmark previews) to be truncated or displayed improperly.

To resolve this, the min-w-[25rem] CSS class has been added to the [HoarderCard] This sets a minimum width for the card, ensuring it has enough space to render its content fully and clearly, regardless of the layout.


## How to test

1. Perform any search on Google.
2. Observe the "Hoarder" card injected into the search results page by the extension.
3. Verify that the card now has a fixed minimum width and its content is fully visible without truncation.
Commits