### PR TITLE
perf: Optimize content script initialization timing 

### DIFF
--- a/content/content.tsx
+++ b/content/content.tsx
@@ -1,9 +1,9 @@
 import '~/styles/tailwind.css'
-import { createRoot } from 'react-dom/client'
-import { userSitesAtom } from '~/atoms/storage'
-import { getRenderRoot } from '~/lib/search-engines'
-import { store } from '~/store'
-import { ContentRoot } from './ContentRoot'
+import {createRoot} from 'react-dom/client'
+import {userSitesAtom} from '~/atoms/storage'
+import {getRenderRoot} from '~/lib/search-engines'
+import {store} from '~/store'
+import {ContentRoot} from './ContentRoot'
 
 let unmount: (() => void) | undefined
 
@@ -12,12 +12,10 @@ if (import.meta.webpackHot) {
   import.meta.webpackHot?.dispose(() => unmount?.())
 }
 
-if (document.readyState === 'complete') {
-  initial()
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', initial)
 } else {
-  document.addEventListener('readystatechange', () => {
-    if (document.readyState === 'complete') initial()
-  })
+  initial()
 }
 
 async function initial() {

--- a/content/content.tsx
+++ b/content/content.tsx
@@ -1,9 +1,9 @@
 import '~/styles/tailwind.css'
-import {createRoot} from 'react-dom/client'
-import {userSitesAtom} from '~/atoms/storage'
-import {getRenderRoot} from '~/lib/search-engines'
-import {store} from '~/store'
-import {ContentRoot} from './ContentRoot'
+import { createRoot } from 'react-dom/client'
+import { userSitesAtom } from '~/atoms/storage'
+import { getRenderRoot } from '~/lib/search-engines'
+import { store } from '~/store'
+import { ContentRoot } from './ContentRoot'
 
 let unmount: (() => void) | undefined
 


### PR DESCRIPTION
### Perf: Optimize content script initialization timing

**Description:**

This pull request optimizes the initialization timing of the content script. Previously, the script waited for `document.readyState` to be `'complete'`, which meant it had to wait for all page resources, including images and iframes, to finish loading.

This change updates the logic to initialize the script on the `DOMContentLoaded` event instead. This allows our script to run as soon as the main DOM is ready, without being blocked by other resources. As a result, the extension's UI should appear sooner on web pages, improving perceived performance and responsiveness.

**Changes:**

*   Modified `content/content.tsx` to trigger the `initial()` function on the `DOMContentLoaded` event if the document is still in a `loading` state.
*   If `DOMContentLoaded` has already fired, the script initializes immediately, ensuring it runs reliably regardless of the initial load state.