### PR TITLE
fix(search): use minimal bookmark schema to avoid output validation errors

### DIFF
--- a/openspec/changes/archive/2026-04-26-minimal-bookmark-schema/.openspec.yaml
+++ b/openspec/changes/archive/2026-04-26-minimal-bookmark-schema/.openspec.yaml
@@ -1,0 +1,6 @@
+schema: spec-driven
+created: 2026-04-26
+created_by: DanSnow <dododavid006@gmail.com>
+created_with: claude
+archived_by: DanSnow <dododavid006@gmail.com>
+archived_at: 2026-04-26

--- a/openspec/changes/archive/2026-04-26-minimal-bookmark-schema/proposal.md
+++ b/openspec/changes/archive/2026-04-26-minimal-bookmark-schema/proposal.md
@@ -1,0 +1,33 @@
+## Why
+
+Fixes [GitHub issue #1395](https://github.com/DanSnow/hoarder-pipette/issues/1395) — "Error on some searches": users see `An error occurred: Output validation failed` on certain searches while other searches work fine.
+
+The `searchBookmark` oRPC handler validates API responses against the full auto-generated `zBookmark` schema, which includes strict enums (`taggingStatus`, `summarizationStatus`) and many fields the extension never reads. When a specific bookmark has a status value outside the expected enum or an unexpected field combination, Zod throws `Output validation failed`, causing the entire search to fail for that user — even though the extension only needs a small subset of fields to render results.
+
+## What Changes
+
+- Replace the `zBookmark` output schema in `searchBookmark` with a minimal hand-written schema containing only the fields the extension actually renders
+- The new schema uses `z.string()` for status fields (no strict enums) and omits all unused fields
+- `BookmarkList` and `BookmarkPreview` prop types are updated to use the new minimal schema type
+
+## Non-Goals
+
+- Not regenerating or updating the auto-generated client files (`zod.gen.ts`, `types.gen.ts`, `sdk.gen.ts`)
+- Not changing how bookmarks are fetched or displayed
+- Not adding support for `text` or `asset` bookmark types in the UI (they are still filtered out in `BookmarkList`)
+
+## Capabilities
+
+### New Capabilities
+
+- `bookmark-search-result`: Minimal validated schema for bookmark search results returned to the extension UI
+
+### Modified Capabilities
+
+(none)
+
+## Impact
+
+- Affected code:
+  - New: `src/schemas/bookmark-search-result.ts`
+  - Modified: `src/orpc/index.ts`, `src/components/BookmarkList.tsx`, `src/components/BookmarkPreview.tsx`

--- a/openspec/changes/archive/2026-04-26-minimal-bookmark-schema/specs/bookmark-search-result/spec.md
+++ b/openspec/changes/archive/2026-04-26-minimal-bookmark-schema/specs/bookmark-search-result/spec.md
@@ -1,0 +1,45 @@
+## ADDED Requirements
+
+### Requirement: Minimal bookmark search result schema
+The system SHALL define a `zBookmarkSearchResult` Zod schema in `src/schemas/bookmark-search-result.ts` containing only the fields consumed by the extension UI. The schema SHALL NOT include strict enum validation for server-side status fields. Fields not used by the UI SHALL be omitted entirely.
+
+The schema SHALL include:
+- `id`: `z.string()`
+- `createdAt`: `z.string()`
+- `content`: a discriminated union on `type`, with a fully-typed `link` variant and a catch-all variant
+- `tags`: array of objects with `id` and `name` as strings
+
+The `link` content variant SHALL include: `url`, `title` (nullish string), `description` (nullish string), `imageUrl` (nullish string).
+
+The catch-all content variant SHALL accept any `type` string value and no other required fields, so that `text`, `asset`, and `unknown` bookmarks pass validation without error.
+
+#### Scenario: Link bookmark passes validation
+- **WHEN** the API returns a bookmark with `content.type === 'link'`
+- **THEN** the schema SHALL validate successfully and expose `url`, `title`, `description`, `imageUrl`
+
+#### Scenario: Non-link bookmark passes validation
+- **WHEN** the API returns a bookmark with `content.type` of `'text'`, `'asset'`, or `'unknown'`
+- **THEN** the schema SHALL validate successfully without throwing an output validation error
+
+##### Example: status enum variance
+- **GIVEN** a bookmark where `taggingStatus` is `'running'` (not in the original enum)
+- **WHEN** the API response is validated against `zBookmarkSearchResult`
+- **THEN** validation SHALL succeed because `taggingStatus` is not part of the schema
+
+#### Scenario: Missing optional fields pass validation
+- **WHEN** a link bookmark has `null` or absent `title`, `description`, or `imageUrl`
+- **THEN** the schema SHALL validate successfully
+
+### Requirement: searchBookmark uses minimal schema
+The `searchBookmark` oRPC handler in `src/orpc/index.ts` SHALL use `z.array(zBookmarkSearchResult)` as its output schema instead of `z.array(zBookmark)`.
+
+#### Scenario: Search succeeds for bookmarks that previously failed
+- **WHEN** the Karakeep API returns bookmarks with unexpected status values or extra fields
+- **THEN** the handler SHALL return results successfully instead of throwing `Output validation failed`
+
+### Requirement: UI components typed against minimal schema
+`BookmarkList` and `BookmarkPreview` SHALL use `z.infer<typeof zBookmarkSearchResult>` as their bookmark prop type instead of `z.infer<typeof zBookmark>`.
+
+#### Scenario: Components compile with new type
+- **WHEN** `zBookmarkSearchResult` is used as the prop type
+- **THEN** TypeScript SHALL compile without errors because all accessed fields are present in the minimal schema

--- a/openspec/changes/archive/2026-04-26-minimal-bookmark-schema/tasks.md
+++ b/openspec/changes/archive/2026-04-26-minimal-bookmark-schema/tasks.md
@@ -1,0 +1,16 @@
+## 1. Define minimal bookmark search result schema
+
+- [x] 1.1 Implement "Minimal bookmark search result schema": create `src/schemas/bookmark-search-result.ts` with the `zBookmarkSearchResult` Zod schema: `id` (string), `createdAt` (string), `content` (discriminated union with a `link` variant containing `url`, `title`, `description`, `imageUrl` all nullish except `url`, plus a catch-all variant `z.object({ type: z.string() })`), and `tags` (array of `{ id: string, name: string }`)
+
+## 2. Wire minimal schema into oRPC handler
+
+- [x] 2.1 Implement "searchBookmark uses minimal schema": update `src/orpc/index.ts` to import `zBookmarkSearchResult` from `~/schemas/bookmark-search-result`, replace `.output(z.array(zBookmark))` with `.output(z.array(zBookmarkSearchResult))` on the `searchBookmark` handler, and remove the unused `zBookmark` import
+
+## 3. Update UI component prop types to use minimal schema
+
+- [x] 3.1 Implement "UI components typed against minimal schema" in `src/components/BookmarkList.tsx`: replace `z.infer<typeof zBookmark>` with `z.infer<typeof zBookmarkSearchResult>` in the `BookmarkListProps` interface and update the import
+- [x] 3.2 Implement "UI components typed against minimal schema" in `src/components/BookmarkPreview.tsx`: replace `z.infer<typeof zBookmark>` with `z.infer<typeof zBookmarkSearchResult>` in the prop type and update the import
+
+## 4. Verify
+
+- [x] 4.1 Run `pnpm tsc --noEmit` (or equivalent type check) and confirm zero TypeScript errors related to the changed files

--- a/openspec/specs/bookmark-search-result/spec.md
+++ b/openspec/specs/bookmark-search-result/spec.md
@@ -1,0 +1,88 @@
+# bookmark-search-result Specification
+
+## Purpose
+
+TBD - created by archiving change 'minimal-bookmark-schema'. Update Purpose after archive.
+
+## Requirements
+
+### Requirement: Minimal bookmark search result schema
+The system SHALL define a `zBookmarkSearchResult` Zod schema in `src/schemas/bookmark-search-result.ts` containing only the fields consumed by the extension UI. The schema SHALL NOT include strict enum validation for server-side status fields. Fields not used by the UI SHALL be omitted entirely.
+
+The schema SHALL include:
+- `id`: `z.string()`
+- `createdAt`: `z.string()`
+- `content`: a discriminated union on `type`, with a fully-typed `link` variant and a catch-all variant
+- `tags`: array of objects with `id` and `name` as strings
+
+The `link` content variant SHALL include: `url`, `title` (nullish string), `description` (nullish string), `imageUrl` (nullish string).
+
+The catch-all content variant SHALL accept any `type` string value and no other required fields, so that `text`, `asset`, and `unknown` bookmarks pass validation without error.
+
+#### Scenario: Link bookmark passes validation
+- **WHEN** the API returns a bookmark with `content.type === 'link'`
+- **THEN** the schema SHALL validate successfully and expose `url`, `title`, `description`, `imageUrl`
+
+#### Scenario: Non-link bookmark passes validation
+- **WHEN** the API returns a bookmark with `content.type` of `'text'`, `'asset'`, or `'unknown'`
+- **THEN** the schema SHALL validate successfully without throwing an output validation error
+
+##### Example: status enum variance
+- **GIVEN** a bookmark where `taggingStatus` is `'running'` (not in the original enum)
+- **WHEN** the API response is validated against `zBookmarkSearchResult`
+- **THEN** validation SHALL succeed because `taggingStatus` is not part of the schema
+
+#### Scenario: Missing optional fields pass validation
+- **WHEN** a link bookmark has `null` or absent `title`, `description`, or `imageUrl`
+- **THEN** the schema SHALL validate successfully
+
+
+<!-- @trace
+source: minimal-bookmark-schema
+updated: 2026-04-26
+code:
+  - src/orpc/index.ts
+  - src/schemas/bookmark-search-result.ts
+  - src/entrypoints/background/index.ts
+  - src/components/BookmarkList.tsx
+  - src/components/BookmarkPreview.tsx
+-->
+
+---
+### Requirement: searchBookmark uses minimal schema
+The `searchBookmark` oRPC handler in `src/orpc/index.ts` SHALL use `z.array(zBookmarkSearchResult)` as its output schema instead of `z.array(zBookmark)`.
+
+#### Scenario: Search succeeds for bookmarks that previously failed
+- **WHEN** the Karakeep API returns bookmarks with unexpected status values or extra fields
+- **THEN** the handler SHALL return results successfully instead of throwing `Output validation failed`
+
+
+<!-- @trace
+source: minimal-bookmark-schema
+updated: 2026-04-26
+code:
+  - src/orpc/index.ts
+  - src/schemas/bookmark-search-result.ts
+  - src/entrypoints/background/index.ts
+  - src/components/BookmarkList.tsx
+  - src/components/BookmarkPreview.tsx
+-->
+
+---
+### Requirement: UI components typed against minimal schema
+`BookmarkList` and `BookmarkPreview` SHALL use `z.infer<typeof zBookmarkSearchResult>` as their bookmark prop type instead of `z.infer<typeof zBookmark>`.
+
+#### Scenario: Components compile with new type
+- **WHEN** `zBookmarkSearchResult` is used as the prop type
+- **THEN** TypeScript SHALL compile without errors because all accessed fields are present in the minimal schema
+
+<!-- @trace
+source: minimal-bookmark-schema
+updated: 2026-04-26
+code:
+  - src/orpc/index.ts
+  - src/schemas/bookmark-search-result.ts
+  - src/entrypoints/background/index.ts
+  - src/components/BookmarkList.tsx
+  - src/components/BookmarkPreview.tsx
+-->

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10648,7 +10648,7 @@ snapshots:
 
   '@types/sax@1.2.7':
     dependencies:
-      '@types/node': 24.12.2
+      '@types/node': 25.5.2
 
   '@types/statuses@2.0.6': {}
 

--- a/src/components/BookmarkList.tsx
+++ b/src/components/BookmarkList.tsx
@@ -1,11 +1,9 @@
 import { Array, pipe } from 'effect'
-import type { z } from 'zod/v4'
-
 import { BookmarkPreview } from '~/components/BookmarkPreview'
-import type { zBookmarkSearchResult } from '~/schemas/bookmark-search-result'
+import type { BookmarkSearchResult } from '~/schemas/bookmark-search-result'
 
 interface BookmarkListProps {
-  bookmarks: z.infer<typeof zBookmarkSearchResult>[] | undefined
+  bookmarks: BookmarkSearchResult[] | undefined
   isPending: boolean
   error: Error | null
 }

--- a/src/components/BookmarkList.tsx
+++ b/src/components/BookmarkList.tsx
@@ -2,10 +2,10 @@ import { Array, pipe } from 'effect'
 import type { z } from 'zod/v4'
 
 import { BookmarkPreview } from '~/components/BookmarkPreview'
-import type { zBookmark } from '~/shared/client/zod.gen'
+import type { zBookmarkSearchResult } from '~/schemas/bookmark-search-result'
 
 interface BookmarkListProps {
-  bookmarks: z.infer<typeof zBookmark>[] | undefined
+  bookmarks: z.infer<typeof zBookmarkSearchResult>[] | undefined
   isPending: boolean
   error: Error | null
 }

--- a/src/components/BookmarkPreview.tsx
+++ b/src/components/BookmarkPreview.tsx
@@ -8,13 +8,14 @@ import type { z } from 'zod/v4'
 
 import { optionsAtom } from '~/atoms/storage'
 import { BOOKMARK_PLACEHOLDER_SVG, decodeEntities, formattedDate } from '~/lib/utils'
-import type { zBookmark } from '~/shared/client/zod.gen'
+import type { zBookmarkSearchResult } from '~/schemas/bookmark-search-result'
 import { orpc } from '~/shared/context' // Import orpc client
 
-export function BookmarkPreview({ bookmark }: { bookmark: z.infer<typeof zBookmark> }) {
+export function BookmarkPreview({ bookmark }: { bookmark: z.infer<typeof zBookmarkSearchResult> }) {
   invariant(bookmark.content.type === 'link', 'bookmark is not link')
 
-  const { imageUrl, title, description } = bookmark.content
+  const content = bookmark.content as Extract<typeof bookmark.content, { type: 'link' }>
+  const { imageUrl, title, description } = content
   const { url } = useAtomValue(optionsAtom)
 
   const isFirefox = import.meta.env.EXTENSION_BROWSER === 'firefox'
@@ -63,7 +64,7 @@ export function BookmarkPreview({ bookmark }: { bookmark: z.infer<typeof zBookma
         <div className="min-w-0 flex-1">
           <div className="flex items-start justify-between gap-2">
             <a
-              href={bookmark.content.url}
+              href={content.url}
               target="_blank"
               rel="noreferrer noopener"
               className="-mx-1 -my-0.5 block rounded-sm px-1 hover:underline focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:outline-none"
@@ -86,7 +87,7 @@ export function BookmarkPreview({ bookmark }: { bookmark: z.infer<typeof zBookma
               </div>
             )}
 
-            {bookmark.content.url && url && (
+            {content.url && url && (
               <>
                 <span className="mx-2">•</span>
                 <a

--- a/src/components/BookmarkPreview.tsx
+++ b/src/components/BookmarkPreview.tsx
@@ -4,14 +4,12 @@ import { Clock, ExternalLink } from 'lucide-react'
 import { useEffect, useState } from 'react'
 import invariant from 'tiny-invariant'
 import { joinURL } from 'ufo'
-import type { z } from 'zod/v4'
-
 import { optionsAtom } from '~/atoms/storage'
 import { BOOKMARK_PLACEHOLDER_SVG, decodeEntities, formattedDate } from '~/lib/utils'
-import type { zBookmarkSearchResult } from '~/schemas/bookmark-search-result'
+import type { BookmarkSearchResult } from '~/schemas/bookmark-search-result'
 import { orpc } from '~/shared/context' // Import orpc client
 
-export function BookmarkPreview({ bookmark }: { bookmark: z.infer<typeof zBookmarkSearchResult> }) {
+export function BookmarkPreview({ bookmark }: { bookmark: BookmarkSearchResult }) {
   invariant(bookmark.content.type === 'link', 'bookmark is not link')
 
   const content = bookmark.content as Extract<typeof bookmark.content, { type: 'link' }>

--- a/src/entrypoints/background/index.ts
+++ b/src/entrypoints/background/index.ts
@@ -1,3 +1,4 @@
+import { onError } from '@orpc/server'
 import { RPCHandler } from '@orpc/server/message-port'
 import { browser } from 'wxt/browser'
 
@@ -8,7 +9,13 @@ import { migrateData } from './migrate'
 import { BackgroundRuntime } from './runtime'
 
 export default defineBackground(() => {
-  const handler = new RPCHandler(appRouter)
+  const handler = new RPCHandler(appRouter, {
+    interceptors: [
+      onError((error) => {
+        console.error('[orpc] error:', error)
+      }),
+    ],
+  })
 
   browser.runtime.onConnect.addListener((port) => {
     handler.upgrade(port, {

--- a/src/orpc/index.ts
+++ b/src/orpc/index.ts
@@ -8,7 +8,7 @@ import { getSupportedSearchEngines, registerAll } from '~/entrypoints/background
 import { BackgroundRuntime } from '~/entrypoints/background/runtime'
 import { SupportSearchEnginesSchema } from '~/schemas/supported-engines'
 import { createClient } from '~/shared/client/client'
-import { zBookmark } from '~/shared/client/zod.gen'
+import { zBookmarkSearchResult } from '~/schemas/bookmark-search-result'
 import { karakeep } from '~/shared/karakeep'
 import { store } from '~/store' // Import store
 
@@ -59,7 +59,7 @@ export const appRouter = os.router({
     }),
   searchBookmark: os
     .input(z.object({ text: z.string() })) // Correct input structure
-    .output(z.array(zBookmark))
+    .output(z.array(zBookmarkSearchResult))
     .handler(async ({ input }) => {
       const options = await store.get(optionsAtom) // Use store.get
       if (!options.apiKey || !options.url) {

--- a/src/schemas/bookmark-search-result.ts
+++ b/src/schemas/bookmark-search-result.ts
@@ -20,7 +20,7 @@ export const zBookmarkSearchResult = z.object({
       id: z.string(),
       name: z.string(),
     }),
-  ),
+  ).catch([]),
 })
 
 export type BookmarkSearchResult = z.infer<typeof zBookmarkSearchResult>

--- a/src/schemas/bookmark-search-result.ts
+++ b/src/schemas/bookmark-search-result.ts
@@ -1,0 +1,26 @@
+import { z } from 'zod/v4'
+
+export const zBookmarkSearchResult = z.object({
+  id: z.string(),
+  createdAt: z.string(),
+  content: z.union([
+    z.object({
+      type: z.literal('link'),
+      url: z.string(),
+      title: z.string().nullish(),
+      description: z.string().nullish(),
+      imageUrl: z.string().nullish(),
+    }),
+    z.object({
+      type: z.string(),
+    }),
+  ]),
+  tags: z.array(
+    z.object({
+      id: z.string(),
+      name: z.string(),
+    }),
+  ),
+})
+
+export type BookmarkSearchResult = z.infer<typeof zBookmarkSearchResult>


### PR DESCRIPTION
Fixes #1395

## Problem

The `searchBookmark` oRPC handler validated API responses against the full auto-generated `zBookmark` schema, which includes strict enums (`taggingStatus`, `summarizationStatus`: `'success' | 'failure' | 'pending'`) and many fields the extension never reads. When a specific bookmark has a status value outside the expected enum, Zod throws `Output validation failed`, causing the entire search to fail — even though the extension only needs a small subset of fields to render results.

## Solution

Replace `zBookmark` with a hand-written `zBookmarkSearchResult` schema containing only the fields the UI actually renders:

- `id`, `createdAt`
- `content` — union of a typed `link` variant (`url`, `title`, `description`, `imageUrl`) and a catch-all for `text`/`asset`/`unknown`
- `tags[].id`, `tags[].name`

Status fields and all other unused fields are absent from the schema, so unexpected API values are silently ignored instead of throwing.

Also adds an `onError` interceptor to the background `RPCHandler` to log oRPC errors to the extension console for easier debugging.